### PR TITLE
Improve swap_gitid 

### DIFF
--- a/build-tools/vivado_tcl/swap_gitid.tcl
+++ b/build-tools/vivado_tcl/swap_gitid.tcl
@@ -19,148 +19,187 @@
 #   set_property BITSTREAM.CONFIG.USERID "32'hFEED0070" [current_design]
 #   write_bitstream -force test3.bit
 
-proc reorder_8bit {gitid} {
+# Useful constants
+variable GITID_LENGTH 40
+variable INIT_LENGTH  69
+variable RECORD_MARKER 800A
+
+# Checks if vivado has finished implementation
+proc check_impl {} {
+    set impl_runs [get_runs impl_*]
+    if {$impl_runs eq ""} {
+        puts "string is empty"
+    }
+}
+
+
+# Checks if GIT ID has a proper length
+proc check_gitid {gitid} {
+    if {[string length $gitid] != $::GITID_LENGTH } {
+        puts "ERROR: Git commit ID must be 40 characters long!"
+        return 0
+    }
+
+}
+
+
+# Checks if init files has a proper length and proper record markers at the correct place
+proc check_init {init0 init1 rowwidth} {
+    if {[string length $init0] != $::INIT_LENGTH } {
+        puts "ERROR: Unexpected length of init0"
+        return 0
+    }
+    if {[string length $init1] != $::INIT_LENGTH } {
+        puts "ERROR: Unexpected length of init1"
+        return 0
+    }
+
+    switch $rowwidth {
+        8 {
+            if { [string range $init0 67 68] != "0A" || \
+                 [string range $init0 45 46] != "0A" || \
+                 [string range $init1 67 68] != "80" || \
+                 [string range $init1 45 46] != "80"} {
+                puts "Could not locate record markers ($::RECORD_MARKER) inside Init files !"
+                return 0
+            }
+        }
+        16 {
+            if { [string range $init0 65 68] != "800A" || \
+                 [string range $init0 21 24] != "800A"} {
+                puts "Could not locate record markers ($::RECORD_MARKER) inside Init files !"
+                return 0
+            }
+        }
+    }
+}
+
+
+proc reorder_bits {gitid rowwidth} {
+    if {!($rowwidth == 8 || $rowwidth == 16)} {
+        puts "rowwidth must be 4 or 8! It is currently: $rowwidth"
+        return 0
+    }
+
     set msb ""
     set lsb ""
-    for {set jx 0} {$jx < 20} {incr jx} {
-        set p [string range $gitid 0 1]
-        set lsb "${p}${lsb}"
-        set p [string range $gitid 2 3]
-        set msb "${p}${msb}"
-        set gitid [string range $gitid 4 999]
+
+    switch $rowwidth { 
+        8 {
+            for {set jx 0} {$jx < 20} {incr jx} {
+                set p [string range $gitid 0 1]
+                set lsb "${p}${lsb}"
+                set p [string range $gitid 2 3]
+                set msb "${p}${msb}"
+                set gitid [string range $gitid 4 999]
+            }
+            return "$msb $lsb"
+        }
+    
+        16 { 
+            for {set jx 0} {$jx < 4} {incr jx} {
+                set p [string range $gitid 0 3]
+                set lsb "${p}${lsb}"
+                set gitid [string range $gitid 4 999]
+            }
+            for {set jx 0} {$jx < 6} {incr jx} {
+                set p [string range $gitid 0 3]
+                set msb "${p}${msb}"
+                set gitid [string range $gitid 4 999]
+            }
+            return "$msb $lsb"
+         }  
+        default {puts "Invalid rowwidth parameter"}
     }
-    # puts "reorder_8bit msb $msb"
-    # puts "reorder_8bit lsb $lsb"
-    return "$msb $lsb"
 }
 
-# Portable string handling
-proc gitid_proc8 {old_commit new_commit init0 init1} {
-    # Check for config_romx record markers, 800A for 10-word binary records
-    if {[string range $init0 67 68] != "0A"} {return 0}
-    if {[string range $init0 45 46] != "0A"} {return 0}
-    if {[string range $init1 67 68] != "80"} {return 0}
-    if {[string range $init1 45 46] != "80"} {return 0}
-    # Check that the existing INIT values match $old_commit -- this is key!
-    lassign [reorder_8bit $old_commit] old_msb old_lsb
-    if {[string range $init0 25 44] != $old_msb} {return 0}
-    if {[string range $init1 25 44] != $old_lsb} {return 0}
-    # Finally insert $new_commit in place
-    lassign [reorder_8bit $new_commit] new_msb new_lsb
-    set init0x "[string range $init0 0 24]$new_msb[string range $init0 45 68]"
-    set init1x "[string range $init1 0 24]$new_lsb[string range $init1 45 68]"
-    puts "old 0 $init0"
-    puts "new 0 $init0x"
-    puts "--"
-    puts "old 1 $init1"
-    puts "new 1 $init1x"
-    puts "--"
-    return "$init0x $init1x"
+
+proc gitid_proc {old_commit new_commit init0 init1 rowwidth} {
+
+    # Security checks
+    check_gitid $old_commit
+    check_gitid $new_commit 
+    check_init $init0 $init1 $rowwidth
+    
+    # Get the MSB and LSB from the old commit hash
+    lassign [reorder_bits $old_commit $rowwidth] old_msb old_lsb
+
+    switch $rowwidth { 
+
+        8 {
+            # Check that the existing INIT values match $old_commit -- this is key!
+            if {[string range $init0 25 44] != $old_msb} {
+                puts "ERROR: init0 file and old MSB values do not match!"
+                return 0
+                }
+            if {[string range $init1 25 44] != $old_lsb} {
+                puts "ERROR: init1 file and old LSB values do not match!"
+                return 0
+                }
+
+            # Finally insert $new_commit in place
+            lassign [reorder_bits $new_commit $rowwidth] new_msb new_lsb
+            set new_init0 "[string range $init0 0 24]$new_msb[string range $init0 45 68]"
+            set new_init1 "[string range $init1 0 24]$new_lsb[string range $init1 45 68]"
+        }
+
+        16 {
+            # Check that the existing INIT values match $old_commit -- this is key!
+            if {[string range $init0 5 20] != $old_lsb} {
+                puts "ERROR: init0 file and old MSB values do not match!"
+                return 0
+                }
+            if {[string range $init1 45 68] != $old_msb} {
+                puts "ERROR: init1 file and old LSB values do not match!"
+                return 0
+                }
+
+            # Finally insert $new_commit in place
+            lassign [reorder_bits $new_commit $rowwidth] new_msb new_lsb
+            set new_init0 "[string range $init0 0 4]$new_lsb[string range $init0 21 68]"
+            set new_init1 "[string range $init1 0 44]$new_msb"
+        }
+
+    }
+    return "$new_init0 $new_init1"
+
 }
 
-# Simple test routine for the portable code
-proc test_proc8 {} {
-    set new_commit [string toupper "da39a3ee5e6b4b0d3255bfef95601890afd80709"]
-    set old_commit [string toupper "141ea87834abf012c40a255921e0adf812e89ad5"]
-    set init0 "256'h388F5DDA0643504C4204D5E8F8E0590A12AB781E0AB3F9B0CD799F8FFF2C1F0A"
-    set init1 "256'hE34DC578CA52204E4C409A12AD2125C4F034A814802241CDC38F70929BBB2780"
-    set xx [gitid_proc8 $old_commit $new_commit $init0 $init1]
-    if {[llength $xx] != 2} {return 0}
-    lassign $xx init0x init1x
-    if {$init0x != "256'h388F5DDA0643504C420409D89060EF550D6BEE390AB3F9B0CD799F8FFF2C1F0A"} {return 0}
-    if {$init1x != "256'hE34DC578CA52204E4C4007AF1895BF324B5EA3DA802241CDC38F70929BBB2780"} {return 0}
-    puts OK
-    return 1
-}
 
 # This function needs Vivado and a routed design
-proc swap_gitid8 {old_commit new_commit} {
+proc swap_gitid {old_commit new_commit rowwidth} {
+
+    # Checks if implementation stage is there
+    check_impl
+
     set c0 [get_cells -hier -filter {PRIMITIVE_TYPE =~ BMEM.*.*} *dxx_reg_0]
-    if {[llength $c0] != 1} {return 0}
+
+    if {[llength $c0] != 1} {
+        puts "ERROR: Unexpected number of dxx_reg_0!"
+        return 0
+    }
     set c1 [get_cells -hier -filter {PRIMITIVE_TYPE =~ BMEM.*.*} *dxx_reg_1]
-    if {[llength $c1] != 1} {return 0}
-    if {[get_property READ_WIDTH_A $c0] != 9} {return 0}
-    if {[get_property READ_WIDTH_A $c1] != 9} {return 0}
+    if {[llength $c1] != 1} {
+        puts "ERROR: Unexpected number of dxx_reg_1!"
+        return 0
+    }
+    if {[get_property READ_WIDTH_A $c0] != 9} {
+        puts "ERROR: Read Width of dxx_reg_0 must be 9!"
+        return 0
+    }
+    if {[get_property READ_WIDTH_A $c1] != 9} {
+        puts "ERROR: Read Width of dxx_reg_1 must be 9!"
+        return 0
+    }
+
     set init0 [get_property INIT_00 $c0]
     set init1 [get_property INIT_00 $c1]
-    set xx [gitid_proc8 $old_commit $new_commit $init0 $init1]
-    if {[llength $xx] != 2} {return 0}
+
+    set xx [gitid_proc $old_commit $new_commit $init0 $init1 $rowwidth]
+
     lassign $xx init0x init1x
     set_property INIT_00 $init0x $c0
     set_property INIT_00 $init1x $c1
-    puts "swap_gitid8 success $new_commit"
-    return 1
-}
-
-# Portable string handling
-proc reorder_16bit {gitid} {
-    set lsb ""
-    for {set jx 0} {$jx < 4} {incr jx} {
-        set p [string range $gitid 0 3]
-        set lsb "${p}${lsb}"
-        set gitid [string range $gitid 4 999]
-    }
-    set msb ""
-    for {set jx 0} {$jx < 6} {incr jx} {
-        set p [string range $gitid 0 3]
-        set msb "${p}${msb}"
-        set gitid [string range $gitid 4 999]
-    }
-    # puts "reorder_16bit msb $msb"
-    # puts "reorder_16bit lsb $lsb"
-    return "$msb $lsb"
-}
-
-# Portable string handling
-proc gitid_proc16 {old_commit new_commit init0 init1} {
-    # Check for config_romx record markers, 800A for 10-word binary records
-    if {[string range $init0 65 68] != "800A"} {return 0}
-    if {[string range $init0 21 24] != "800A"} {return 0}
-    # Check that the existing INIT values match $old_commit -- this is key!
-    lassign [reorder_16bit $old_commit] new_msb new_lsb
-    if {[string range $init0 5 20] != $new_lsb} {return 0}
-    if {[string range $init1 45 68] != $new_msb} {return 0}
-    # Finally insert $new_commit in place
-    lassign [reorder_16bit $new_commit] new_msb new_lsb
-    set init0x "[string range $init0 0 4]$new_lsb[string range $init0 21 68]"
-    set init1x "[string range $init1 0 44]$new_msb"
-    puts "old 0 $init0"
-    puts "new 0 $init0x"
-    puts "--"
-    puts "old 1 $init1"
-    puts "new 1 $init1x"
-    puts "--"
-    return "$init0x $init1x"
-}
-
-# Simple test routine for the portable code
-proc test_proc16 {} {
-    set new_commit [string toupper "da39a3ee5e6b4b0d3255bfef95601890afd80709"]
-    set old_commit [string toupper "603045a65af2cbae6570df490578e49af0e53f07"]
-    set init0 "256'hCBAE5AF245A66030800A0F6858D77AC2B85D06D3D8DF2C3E529A12FBDFF5800A"
-    set init1 "256'h78DAC0E66E677469657320546C6572624D6140073F07F0E5E49A0578DF496570"
-    set xx [gitid_proc16 $old_commit $new_commit $init0 $init1]
-    if {[llength $xx] != 2} {return 0}
-    lassign $xx init0x init1x
-    puts $init0x
-    puts $init1x
-    if {$init0x != "256'h4B0D5E6BA3EEDA39800A0F6858D77AC2B85D06D3D8DF2C3E529A12FBDFF5800A"} {return 0}
-    if {$init1x != "256'h78DAC0E66E677469657320546C6572624D6140070709AFD818909560BFEF3255"} {return 0}
     puts OK
-    return 1
-}
-
-# This function needs Vivado and a routed design
-proc swap_gitid16 {old_commit new_commit} {
-    set c0 [get_cells -hier -filter {PRIMITIVE_TYPE =~ BMEM.*.*} *dxx_reg]
-    if {[llength $c0] != 1} {return 0}
-    set init0 [get_property INIT_00 $c0]
-    set init1 [get_property INIT_01 $c0]
-    set xx [gitid_proc16 $old_commit $new_commit $init0 $init1]
-    if {[llength $xx] != 2} {return 0}
-    lassign $xx init0x init1x
-    set_property INIT_00 $init0x $c0
-    set_property INIT_01 $init1x $c0
-    puts "swap_gitid16 success $new_commit"
     return 1
 }

--- a/build-tools/vivado_tcl/test_swap_gitid.tcl
+++ b/build-tools/vivado_tcl/test_swap_gitid.tcl
@@ -1,0 +1,54 @@
+source swap_gitid.tcl
+
+# Test vectors for rowwidth of 8 ############################# 
+set new_commit_8 [string toupper "da39a3ee5e6b4b0d3255bfef95601890afd80709"]
+set old_commit_8 [string toupper "141ea87834abf012c40a255921e0adf812e89ad5"]
+set init0_8 "256'h388F5DDA0643504C4204D5E8F8E0590A12AB781E0AB3F9B0CD799F8FFF2C1F0A"
+set init1_8 "256'hE34DC578CA52204E4C409A12AD2125C4F034A814802241CDC38F70929BBB2780"
+
+# Expected Values
+set golden_init0_8 "256'h388F5DDA0643504C420409D89060EF550D6BEE390AB3F9B0CD799F8FFF2C1F0A"
+set golden_init1_8 "256'hE34DC578CA52204E4C4007AF1895BF324B5EA3DA802241CDC38F70929BBB2780"
+##########
+
+# Test vectors for rowwidth of 16 #############################
+set new_commit_16 [string toupper "da39a3ee5e6b4b0d3255bfef95601890afd80709"]
+set old_commit_16 [string toupper "603045a65af2cbae6570df490578e49af0e53f07"]
+set init0_16 "256'hCBAE5AF245A66030800A0F6858D77AC2B85D06D3D8DF2C3E529A12FBDFF5800A"
+set init1_16 "256'h78DAC0E66E677469657320546C6572624D6140073F07F0E5E49A0578DF496570"
+
+# Expected values
+set golden_init0_16 "256'h4B0D5E6BA3EEDA39800A0F6858D77AC2B85D06D3D8DF2C3E529A12FBDFF5800A"
+set golden_init1_16 "256'h78DAC0E66E677469657320546C6572624D6140070709AFD818909560BFEF3255"
+#########
+
+
+
+# Test Procedure for 8
+set rowwidth 8
+lassign [gitid_proc $old_commit_8 $new_commit_8 $init0_8 $init1_8 $rowwidth] result_init0 result_init1
+
+if {$result_init0 != $golden_init0_8} {
+  puts "Result of rowwidth=8 init0 output is WRONG!"
+} else { puts "Results for rowwidth=8 init0 output is CORRECT!"}
+
+if {$result_init1 != $golden_init1_8} {
+  puts "Result of rowwidth=8 init1 output is WRONG!"
+} else { puts "Results for rowwidth=8 init1 output is CORRECT!"}
+
+
+# Test Procedure for 16
+set rowwidth 16
+lassign [gitid_proc $old_commit_16 $new_commit_16 $init0_16 $init1_16 $rowwidth] result_init0 result_init1
+
+
+if {$result_init0 != $golden_init0_16} {
+  puts "Result of rowwidth=16 init0 output is WRONG!"
+} else { puts "Results for rowwidth=16 init0 output is CORRECT!"}
+
+if {$result_init1 != $golden_init1_16} {
+  puts "Result of rowwidth=16 init1 output is WRONG!"
+} else { puts "Results for rowwidth=16 init1 output is CORRECT!"}
+
+# Test procedure for swapping init values (must have Vivado design open)
+#swap_gitid $old_commit_8 $new_commit_8 8


### PR DESCRIPTION
Improved error handling:

- git commit id length check 
- init file size and structure check 
- check if the Implementation stage (`impl_*`) exists before searching cells

Refactoring:

- Merged 8 and 16-row width procedures into a common one
- Separated unit test of swap_gitid into a separate file
